### PR TITLE
Criando Site Estático para o projeto teste-no-backstage no ambiente Production

### DIFF
--- a/aws/Production/static-site/teste-no-backstage/main.tf
+++ b/aws/Production/static-site/teste-no-backstage/main.tf
@@ -19,8 +19,12 @@ terraform {
 module "cloudfront" {
     source = "git@github.com:fillipepaz/aws-cloudfront-module.git//static-site"
     accountId="704151674151"
-    repoNameAndOrg="fillipe/static-site-example"
+    repoNameAndOrg="fillipepaz/static-site-example"
     bucketName="bucket-teste-no-backstage"
     project="teste-no-backstage" 
     
 }
+
+output "url" {
+    value = module.cloudfront.cloudfrontDns
+  }


### PR DESCRIPTION
### 'Criando Site Estático para o projeto teste-no-backstage no ambiente Production'
#### Platform Engineering Team
![C|Solid](https://media.licdn.com/dms/image/C4D03AQFrRACeL-3RzQ/profile-displayphoto-shrink_200_200/0/1549336419509?e=2147483647&v=beta&t=feIcq_ZKeMNcXd9xjl7ez6TLcIA0vS-8q6vqePrnz1g)
| Atributo | Valor |
| ------ | ------ |
| Owner do projeto | group:default/vendas |
| Projeto | teste-no-backstage |
| Repositório do Site | fillipepaz/static-site-example |
| Ambiente | Production |
| Arquitetura | https://github.com/fillipepaz/aws-cloudfront-module/tree/main/static-site |
