### PR TITLE
Criando Site Estático para o projeto devopsdays-portal no ambiente Production

### DIFF
--- a/aws/Production/static-site/devopsdays-portal/main.tf
+++ b/aws/Production/static-site/devopsdays-portal/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.45.0"
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket = "versioning-terraform-home"
+    key    = "site-estatico/Production/devopsdays-portal/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+
+module "cloudfront" {
+    source = "git@github.com:fillipepaz/aws-cloudfront-module.git//static-site"
+    accountId="704151674151"
+    repoNameAndOrg="fillipepaz/static-site-example"
+    bucketName="bucket-devopsdays-portal"
+    project="devopsdays-portal" 
+    
+}
+
+output "url" {
+    value = module.cloudfront.cloudfrontDns
+  }


### PR DESCRIPTION
### 'Criando Site Estático para o projeto devopsdays-portal no ambiente Production'
#### Platform Engineering Team
![C|Solid](https://media.licdn.com/dms/image/C4D03AQFrRACeL-3RzQ/profile-displayphoto-shrink_200_200/0/1549336419509?e=2147483647&v=beta&t=feIcq_ZKeMNcXd9xjl7ez6TLcIA0vS-8q6vqePrnz1g)
| Atributo | Valor |
| ------ | ------ |
| Owner do projeto | group:default/marketing |
| Projeto | devopsdays-portal |
| Repositório do Site | fillipepaz/static-site-example |
| Ambiente | Production |
| Arquitetura | https://github.com/fillipepaz/aws-cloudfront-module/tree/main/static-site |
